### PR TITLE
fix bug(Character range is out of order) & disable ESlint singlequote rule

### DIFF
--- a/src/steps/completion/completion-equals-ab.ts
+++ b/src/steps/completion/completion-equals-ab.ts
@@ -14,7 +14,7 @@ export class CompletionEqualsAb extends BaseStep implements StepInterface {
   protected stepName: string = 'Compare OpenAI GPT model A and B prompt responses from completion';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = `OpenAI model (?<modela>[a-zA-Z0-9_-.]+) and (?<modelb>[a-zA-Z0-9_-.]+) responses to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
+  protected stepExpression: string = `OpenAI model (?<modela>[a-zA-Z0-9_ -.]+) and (?<modelb>[a-zA-Z0-9_ -.]+) responses to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/completion/completion-equals-ab.ts
+++ b/src/steps/completion/completion-equals-ab.ts
@@ -13,7 +13,7 @@ import { baseOperators } from '../../client/constants/operators';
 export class CompletionEqualsAb extends BaseStep implements StepInterface {
   protected stepName: string = 'Compare OpenAI GPT model A and B prompt responses from completion';
 
-  // tslint:disable-next-line:max-line-length
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<modela>[a-zA-Z0-9_ -.]+) and (?<modelb>[a-zA-Z0-9_ -.]+) responses to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/src/steps/completion/completion-equals.ts
+++ b/src/steps/completion/completion-equals.ts
@@ -12,8 +12,7 @@ import { baseOperators } from '../../client/constants/operators';
 export class CompletionEquals extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response from completion';
 
-  // tslint:disable-next-line:max-line-length
-  // tslint:disable-next-line:quotemark
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/src/steps/completion/completion-equals.ts
+++ b/src/steps/completion/completion-equals.ts
@@ -13,7 +13,8 @@ export class CompletionEquals extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response from completion';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_-.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
+  // tslint:disable-next-line:quotemark
+  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/completion/completion-readability.ts
+++ b/src/steps/completion/completion-readability.ts
@@ -12,7 +12,7 @@ import { baseOperators } from '../../client/constants/operators';
 export class CompletionReadability extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response FRES reading ease evaluation';
 
-  // tslint:disable-next-line:max-line-length
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) school level of the response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be less than|be greater than|be one of|be|not be one of|not be) ?(?<schoollevel>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/src/steps/completion/completion-readability.ts
+++ b/src/steps/completion/completion-readability.ts
@@ -13,7 +13,7 @@ export class CompletionReadability extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response FRES reading ease evaluation';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_-.]+) school level of the response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be less than|be greater than|be one of|be|not be one of|not be) ?(?<schoollevel>.+)?`;
+  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) school level of the response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be less than|be greater than|be one of|be|not be one of|not be) ?(?<schoollevel>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/completion/completion-semantic-similarity.ts
+++ b/src/steps/completion/completion-semantic-similarity.ts
@@ -14,7 +14,7 @@ import { baseOperators } from '../../client/constants/operators';
 export class CompletionSemanticSimilarity extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT semantic similarity of response to provided text from completion';
 
-  // tslint:disable-next-line:max-line-length
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" semantically compared with "(?<comparetext>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/src/steps/completion/completion-semantic-similarity.ts
+++ b/src/steps/completion/completion-semantic-similarity.ts
@@ -15,7 +15,7 @@ export class CompletionSemanticSimilarity extends BaseStep implements StepInterf
   protected stepName: string = 'Check OpenAI GPT semantic similarity of response to provided text from completion';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_-.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" semantically compared with "(?<comparetext>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`;
+  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" semantically compared with "(?<comparetext>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/completion/completion-word-count.ts
+++ b/src/steps/completion/completion-word-count.ts
@@ -12,7 +12,7 @@ import { baseOperators } from '../../client/constants/operators';
 export class CompletionWordCount extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response word count from completion';
 
-  // tslint:disable-next-line:max-line-length
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) word count in a response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/src/steps/completion/completion-word-count.ts
+++ b/src/steps/completion/completion-word-count.ts
@@ -13,7 +13,7 @@ export class CompletionWordCount extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT prompt response word count from completion';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_-.]+) word count in a response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
+  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) word count in a response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/embeddings/embeddings-cosine-similarity.ts
+++ b/src/steps/embeddings/embeddings-cosine-similarity.ts
@@ -15,7 +15,7 @@ export class EmbeddingsCosineSimilarity extends BaseStep implements StepInterfac
   protected stepName: string = 'Check OpenAI GPT cosine similarity of two texts based on embeddings';
 
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'OpenAI model (?<model>[a-zA-Z0-9_-.]+) cosine similarity of "(?<text1>[a-zA-Z0-9_ -]+)" and "(?<text2>[a-zA-Z0-9_ -]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?';
+  protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) cosine similarity of "(?<text1>[a-zA-Z0-9_ -.]+)" and "(?<text2>[a-zA-Z0-9_ -.]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 

--- a/src/steps/embeddings/embeddings-cosine-similarity.ts
+++ b/src/steps/embeddings/embeddings-cosine-similarity.ts
@@ -14,7 +14,7 @@ const similarity = require('compute-cosine-similarity');
 export class EmbeddingsCosineSimilarity extends BaseStep implements StepInterface {
   protected stepName: string = 'Check OpenAI GPT cosine similarity of two texts based on embeddings';
 
-  // tslint:disable-next-line:max-line-length
+  // tslint:disable-next-line:max-line-length quotemark
   protected stepExpression: string = `OpenAI model (?<model>[a-zA-Z0-9_ -.]+) cosine similarity of "(?<text1>[a-zA-Z0-9_ -.]+)" and "(?<text2>[a-zA-Z0-9_ -.]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`;
 
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;

--- a/test/steps/completion/completion-equals-ab.ts
+++ b/test/steps/completion/completion-equals-ab.ts
@@ -23,7 +23,7 @@ describe('CompletionEqualsAb', () => {
       // Here, you would change the expected values to match what CompletionEqualsAb's metadata should return
       expect(stepDef.getStepId()).to.equal('CompletionEqualsAb');
       expect(stepDef.getName()).to.equal('Compare OpenAI GPT model A and B prompt responses from completion');
-      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<modela>[a-zA-Z0-9_-.]+) and (?<modelb>[a-zA-Z0-9_-.]+) responses to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
+      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<modela>[a-zA-Z0-9_ -.]+) and (?<modelb>[a-zA-Z0-9_ -.]+) responses to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
       // And other necessary metadata tests
     });

--- a/test/steps/completion/completion-equals.ts
+++ b/test/steps/completion/completion-equals.ts
@@ -23,7 +23,7 @@ describe('CompletionEquals', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('CompletionEquals');
       expect(stepDef.getName()).to.equal('Check OpenAI GPT prompt response from completion');
-      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_-.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
+      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 

--- a/test/steps/completion/completion-readability.ts
+++ b/test/steps/completion/completion-readability.ts
@@ -23,7 +23,7 @@ describe('CompletionReadability', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('CompletionReadability');
       expect(stepDef.getName()).to.equal('Check OpenAI GPT prompt response FRES reading ease evaluation');
-      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_-.]+) school level of the response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be less than|be greater than|be one of|be|not be one of|not be) ?(?<schoollevel>.+)?`);
+      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_ -.]+) school level of the response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be less than|be greater than|be one of|be|not be one of|not be) ?(?<schoollevel>.+)?`);
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 

--- a/test/steps/completion/completion-semantic-similarity.ts
+++ b/test/steps/completion/completion-semantic-similarity.ts
@@ -22,7 +22,7 @@ describe('CompletionSemanticSimilarity', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('CompletionSemanticSimilarity');
       expect(stepDef.getName()).to.equal('Check OpenAI GPT semantic similarity of response to provided text from completion');
-      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_-.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" semantically compared with "(?<comparetext>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`);
+      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_ -.]+) response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" semantically compared with "(?<comparetext>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<semanticsimilarity>.+)?`);
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 

--- a/test/steps/completion/completion-word-count.ts
+++ b/test/steps/completion/completion-word-count.ts
@@ -22,7 +22,7 @@ describe('CompletionWordCount', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('CompletionWordCount');
       expect(stepDef.getName()).to.equal('Check OpenAI GPT prompt response word count from completion');
-      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_-.]+) word count in a response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
+      expect(stepDef.getExpression()).to.equal(`OpenAI model (?<model>[a-zA-Z0-9_ -.]+) word count in a response to "(?<prompt>[a-zA-Z0-9_ -'".,?!]+)" should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?`);
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 


### PR DESCRIPTION
1. The potential 'Character range is out of order' bug was identified and addressed.
`(?<model>[a-zA-Z0-9_-.]+)` => `(?<model>[a-zA-Z0-9_ -.]+)`

2. Disabled the ESLint single quote rule raised in the Circle CI test in regarding stepExpression.
![image](https://github.com/run-crank/cog-openai/assets/78632105/ba6e1805-6020-4344-8001-e67e99c9cd6c)
![image](https://github.com/run-crank/cog-openai/assets/78632105/2ba610d1-5eb9-4127-8ae4-952fdd91a560)
